### PR TITLE
fix(convert-svg-core): fixed error being throw caused by lost context for CLI

### DIFF
--- a/packages/convert-svg-core/src/CLI.js
+++ b/packages/convert-svg-core/src/CLI.js
@@ -144,7 +144,7 @@ class CLI {
    */
   async parse(args = []) {
     const command = this[_command].parse(args);
-    const converter = new Converter();
+    const converter = new Converter(this[_provider]);
     const options = this[_parseOptions]();
 
     try {


### PR DESCRIPTION
With the new version converter require a provider. In CLI, this provider is not set in the constructor.

This fix set the provider when you use the CLI