### PR TITLE
feat(convert-svg-core): Options can be passed directly to puppeteer.launch

### DIFF
--- a/packages/convert-svg-core/package.json
+++ b/packages/convert-svg-core/package.json
@@ -30,6 +30,8 @@
     "file-url": "^2.0.2",
     "get-stdin": "^5.0.1",
     "glob": "^7.1.2",
+    "lodash.omit": "^4.5.0",
+    "lodash.pick": "^4.4.0",
     "pollock": "^0.1.0",
     "puppeteer": "^0.12.0",
     "tmp": "0.0.33"

--- a/packages/convert-svg-core/src/API.js
+++ b/packages/convert-svg-core/src/API.js
@@ -22,6 +22,9 @@
 
 'use strict';
 
+const omit = require('lodash.omit');
+const pick = require('lodash.pick');
+
 const Converter = require('./Converter');
 
 const _provider = Symbol('provider');
@@ -65,16 +68,16 @@ class API {
    * provided and this information could not be derived from <code>input</code>.
    *
    * @param {Buffer|string} input - the SVG input to be converted to another format
-   * @param {Converter~ConvertOptions} [options] - the options to be used
+   * @param {API~ConvertOptions} [options] - the options to be used
    * @return {Promise.<Buffer, Error>} A <code>Promise</code> that is resolved with the converted output buffer.
    * @public
    */
   async convert(input, options) {
-    const converter = this.createConverter();
+    const converter = this.createConverter(pick(options, 'puppeteer'));
     let output;
 
     try {
-      output = await converter.convert(input, options);
+      output = await converter.convert(input, omit(options, 'puppeteer'));
     } finally {
       await converter.destroy();
     }
@@ -101,16 +104,16 @@ class API {
    * writing the output file.
    *
    * @param {string} inputFilePath - the path of the SVG file to be converted to another file format
-   * @param {Converter~ConvertFileOptions} [options] - the options to be used
+   * @param {API~ConvertFileOptions} [options] - the options to be used
    * @return {Promise.<string, Error>} A <code>Promise</code> that is resolved with the output file path.
    * @public
    */
   async convertFile(inputFilePath, options) {
-    const converter = this.createConverter();
+    const converter = this.createConverter(pick(options, 'puppeteer'));
     let outputFilePath;
 
     try {
-      outputFilePath = await converter.convertFile(inputFilePath, options);
+      outputFilePath = await converter.convertFile(inputFilePath, omit(options, 'puppeteer'));
     } finally {
       await converter.destroy();
     }
@@ -119,7 +122,7 @@ class API {
   }
 
   /**
-   * Creates an instance of {@link Converter}.
+   * Creates an instance of {@link Converter} using the <code>options</code> provided.
    *
    * It is important to note that, after the first time either {@link Converter#convert} or
    * {@link Converter#convertFile} are called, a headless Chromium instance will remain open until
@@ -130,11 +133,12 @@ class API {
    * files in another format and then destroy it afterwards. It's not recommended to keep an instance around for too
    * long, as it will use up resources.
    *
+   * @param {API~CreateConverterOptions} [options] - the options to be used
    * @return {Converter} A newly created {@link Converter} instance.
    * @public
    */
-  createConverter() {
-    return new Converter(this.provider);
+  createConverter(options) {
+    return new Converter(this.provider, options);
   }
 
   /**
@@ -160,3 +164,27 @@ class API {
 }
 
 module.exports = API;
+
+/**
+ * The options that can be passed to {@link API#convertFile}.
+ *
+ * @typedef {Converter~ConvertFileOptions} API~ConvertFileOptions
+ * @property {Object} [puppeteer] - The options that are to be passed directly to <code>puppeteer.launch</code> when
+ * creating the <code>Browser</code> instance.
+ */
+
+/**
+ * The options that can be passed to {@link API#convert}.
+ *
+ * @typedef {Converter~ConvertOptions} API~ConvertOptions
+ * @property {Object} [puppeteer] - The options that are to be passed directly to <code>puppeteer.launch</code> when
+ * creating the <code>Browser</code> instance.
+ */
+
+/**
+ * The options that can be passed to {@link API#createConverter}.
+ *
+ * @typedef {Converter~Options} API~CreateConverterOptions
+ * @property {Object} [puppeteer] - The options that are to be passed directly to <code>puppeteer.launch</code> when
+ * creating the <code>Browser</code> instance.
+ */

--- a/packages/convert-svg-core/src/Converter.js
+++ b/packages/convert-svg-core/src/Converter.js
@@ -40,6 +40,7 @@ const _destroyed = Symbol('destroyed');
 const _getDimensions = Symbol('getDimensions');
 const _getPage = Symbol('getPage');
 const _getTempFile = Symbol('getTempFile');
+const _options = Symbol('options');
 const _page = Symbol('page');
 const _parseOptions = Symbol('parseOptions');
 const _provider = Symbol('provider');
@@ -71,13 +72,16 @@ const _validate = Symbol('validate');
 class Converter {
 
   /**
-   * Creates an instance of {@link Converter} using the specified <code>provider</code>.
+   * Creates an instance of {@link Converter} using the specified <code>provider</code> and the <code>options</code>
+   * provided.
    *
    * @param {Provider} provider - the {@link Provider} to be used
+   * @param {Converter~Options} [options] - the options to be used
    * @public
    */
-  constructor(provider) {
+  constructor(provider, options) {
     this[_provider] = provider;
+    this[_options] = Object.assign({}, options);
     this[_destroyed] = false;
   }
 
@@ -266,7 +270,7 @@ html { background-color: ${provider.getBackgroundColor(options)}; }
 
   async [_getPage](html) {
     if (!this[_browser]) {
-      this[_browser] = await puppeteer.launch();
+      this[_browser] = await puppeteer.launch(this[_options].puppeteer);
       this[_page] = await this[_browser].newPage();
     }
 
@@ -416,4 +420,12 @@ module.exports = Converter;
  * derived).
  * @property {number|string} [width] - The width of the output to be generated. If omitted, an attempt will be made to
  * derive the width from the SVG input.
+ */
+
+/**
+ * The options that can be passed to {@link Converter}.
+ *
+ * @typedef {Object} Converter~Options
+ * @property {Object} [puppeteer] - The options that are to be passed directly to <code>puppeteer.launch</code> when
+ * creating the <code>Browser</code> instance.
  */

--- a/packages/convert-svg-to-jpeg/README.md
+++ b/packages/convert-svg-to-jpeg/README.md
@@ -84,9 +84,13 @@ element or no `width` and/or `height` options were provided and this information
 | `baseFile`   | String        | N/A                     | Path of the file to be converted into a file URL to use for all relative URLs contained within the SVG. Cannot be used in conjunction with the `baseUrl` option. |
 | `baseUrl`    | String        | `"file:///path/to/cwd"` | Base URL to use for all relative URLs contained within the SVG. Cannot be used in conjunction with the `baseFile` option.                                        |
 | `height`     | Number/String | N/A                     | Height of the output to be generated. Derived from SVG input if omitted.                                                                                         |
+| `puppeteer`  | Object        | N/A                     | Options that are to be passed directly to `puppeteer.launch` when creating the `Browser` instance.                                                               |
 | `quality`    | Number        | `100`                   | Quality of the output to be generated.                                                                                                                           |
 | `scale`      | Number        | `1`                     | Scale to be applied to the width and height (specified as options or derived).                                                                                   |
 | `width`      | Number/String | N/A                     | Width of the output to be generated. Derived from SVG input if omitted.                                                                                          |
+
+The `puppeteer` option is not available when calling this method on a `Converter` instance created using
+`createConverter`.
 
 #### Example
 
@@ -144,15 +148,21 @@ const { convertFile}  = require('convert-svg-to-jpeg');
 })();
 ```
 
-### `createConverter()`
+### `createConverter([options])`
 
-Creates an instance of `Converter`.
+Creates an instance of `Converter` using the `options` provided.
 
 It is important to note that, after the first time either `Converter#convert` or `Converter#convertFile` are called, a
 headless Chromium instance will remain open until `Converter#destroy` is called. This is done automatically when using
 the `API` convert methods, however, when using `Converter` directly, it is the responsibility of the caller. Due to the
 fact that creating browser instances is expensive, this level of control allows callers to reuse a browser for multiple
 conversions. It's not recommended to keep an instance around for too long, as it will use up resources.
+
+#### Options
+
+| Option      | Type   | Default | Description                                                                                        |
+| ----------- | ------ | ------- | -------------------------------------------------------------------------------------------------- |
+| `puppeteer` | Object | N/A     | Options that are to be passed directly to `puppeteer.launch` when creating the `Browser` instance. |
 
 #### Example
 

--- a/packages/convert-svg-to-png/README.md
+++ b/packages/convert-svg-to-png/README.md
@@ -83,8 +83,12 @@ element or no `width` and/or `height` options were provided and this information
 | `baseFile`   | String        | N/A                     | Path of the file to be converted into a file URL to use for all relative URLs contained within the SVG. Cannot be used in conjunction with the `baseUrl` option. |
 | `baseUrl`    | String        | `"file:///path/to/cwd"` | Base URL to use for all relative URLs contained within the SVG. Cannot be used in conjunction with the `baseFile` option.                                        |
 | `height`     | Number/String | N/A                     | Height of the output to be generated. Derived from SVG input if omitted.                                                                                         |
+| `puppeteer`  | Object        | N/A                     | Options that are to be passed directly to `puppeteer.launch` when creating the `Browser` instance.                                                               |
 | `scale`      | Number        | `1`                     | Scale to be applied to the width and height (specified as options or derived).                                                                                   |
 | `width`      | Number/String | N/A                     | Width of the output to be generated. Derived from SVG input if omitted.                                                                                          |
+
+The `puppeteer` option is not available when calling this method on a `Converter` instance created using
+`createConverter`.
 
 #### Example
 
@@ -142,15 +146,21 @@ const { convertFile}  = require('convert-svg-to-png');
 })();
 ```
 
-### `createConverter()`
+### `createConverter([options])`
 
-Creates an instance of `Converter`.
+Creates an instance of `Converter` using the `options` provided.
 
 It is important to note that, after the first time either `Converter#convert` or `Converter#convertFile` are called, a
 headless Chromium instance will remain open until `Converter#destroy` is called. This is done automatically when using
 the `API` convert methods, however, when using `Converter` directly, it is the responsibility of the caller. Due to the
 fact that creating browser instances is expensive, this level of control allows callers to reuse a browser for multiple
 conversions. It's not recommended to keep an instance around for too long, as it will use up resources.
+
+#### Options
+
+| Option      | Type   | Default | Description                                                                                        |
+| ----------- | ------ | ------- | -------------------------------------------------------------------------------------------------- |
+| `puppeteer` | Object | N/A     | Options that are to be passed directly to `puppeteer.launch` when creating the `Browser` instance. |
 
 #### Example
 


### PR DESCRIPTION
This implements the feature requested in #25 by allowing options to be passed to [puppeteer.launch](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions).

A new `puppeteer` option has been added to existing `options` parameter for `API#convert` and `API#convertFile` and a new `options` parameter has been added to `API#createConverter` that only contains the `puppeteer` option.