### PR TITLE
Add puppeteer.launch options available into CLI

### DIFF
--- a/packages/convert-svg-to-jpeg/README.md
+++ b/packages/convert-svg-to-jpeg/README.md
@@ -44,6 +44,7 @@ $ npm install --global convert-svg-to-jpeg
         --base-url <url>       specify base URL to use for all relative URLs in SVG
         --filename <filename>  specify filename for the JPEG output when processing STDIN
         --height <value>       specify height for JPEG
+        --puppeteer <json>     specify a json object for puppeteer.launch options
         --scale <value>        specify scale to apply to dimensions [1]
         --width <value>        specify width for JPEG
         --quality <value>      specify quality for JPEG [100]

--- a/packages/convert-svg-to-png/README.md
+++ b/packages/convert-svg-to-png/README.md
@@ -44,6 +44,7 @@ $ npm install --global convert-svg-to-png
         --base-url <url>       specify base URL to use for all relative URLs in SVG
         --filename <filename>  specify filename for the PNG output when processing STDIN
         --height <value>       specify height for PNG
+        --puppeteer <json>     specify a json object for puppeteer.launch options
         --scale <value>        specify scale to apply to dimensions [1]
         --width <value>        specify width for PNG
         -h, --help             output usage information


### PR DESCRIPTION
You have added an awesome option into the API to customize puppeteer. This merge request try to allow use this option into the CLI

Example (because require escape JSON into the CLI... but I don't know how to do this without) : 
```bash
./packages/convert-svg-to-png/bin/convert-svg-to-png --width 300 --puppeteer "{\"args\": [\"--no-sandbox\"],\"dumpio\":true}" *.svg
```