### PR TITLE
Replace chai with assert

### DIFF
--- a/packages/convert-svg-core/package.json
+++ b/packages/convert-svg-core/package.json
@@ -37,8 +37,6 @@
     "tmp": "0.0.33"
   },
   "devDependencies": {
-    "chai": "^4.1.2",
-    "chai-as-promised": "^7.1.1",
     "mocha": "^5.0.0",
     "sinon": "^4.2.2"
   },

--- a/packages/convert-svg-core/test/API.spec.js
+++ b/packages/convert-svg-core/test/API.spec.js
@@ -22,7 +22,7 @@
 
 'use strict';
 
-const { expect } = require('chai');
+const assert = require('assert');
 const sinon = require('sinon');
 
 const API = require('../src/API');
@@ -50,26 +50,28 @@ describe('[convert-svg-core] API', () => {
     it('should return Converter instance using provider', () => {
       const converter = api.createConverter();
 
-      expect(converter).to.be.an.instanceOf(Converter);
-      expect(converter.provider).to.equal(provider);
+      assert.ok(converter instanceof Converter);
+      assert.strictEqual(converter.provider, provider);
     });
 
     it('should never return same instance', () => {
-      expect(api.createConverter()).to.not.equal(api.createConverter());
+      assert.notStrictEqual(api.createConverter(), api.createConverter());
     });
   });
 
   describe('#provider', () => {
     it('should return provider', () => {
-      expect(api.provider).to.equal(provider);
+      assert.strictEqual(api.provider, provider);
     });
   });
 
   describe('#version', () => {
     it('should return provider version', () => {
-      provider.getVersion.returns('0.0.0');
+      const version = '0.0.0';
 
-      expect(api.version).to.equal('0.0.0');
+      provider.getVersion.returns(version);
+
+      assert.equal(api.version, version);
     });
   });
 });

--- a/packages/convert-svg-core/test/CLI.spec.js
+++ b/packages/convert-svg-core/test/CLI.spec.js
@@ -22,7 +22,7 @@
 
 'use strict';
 
-const { expect } = require('chai');
+const assert = require('assert');
 const { EOL } = require('os');
 const sinon = require('sinon');
 const { Writable } = require('stream');
@@ -54,9 +54,11 @@ describe('[convert-svg-core] CLI', () => {
     it('should write message to error stream', () => {
       cli.error('foo');
 
-      expect(outputStream.write.callCount).to.equal(0);
-      expect(errorStream.write.callCount).to.equal(1);
-      expect(errorStream.write.args[0]).to.deep.equal([ `foo${EOL}` ]);
+      assert.equal(outputStream.write.callCount, 0);
+      assert.equal(errorStream.write.callCount, 1);
+      assert.deepEqual(errorStream.write.args, [
+        [ `foo${EOL}` ]
+      ]);
     });
   });
 
@@ -64,9 +66,11 @@ describe('[convert-svg-core] CLI', () => {
     it('should write message to output stream', () => {
       cli.output('foo');
 
-      expect(errorStream.write.callCount).to.equal(0);
-      expect(outputStream.write.callCount).to.equal(1);
-      expect(outputStream.write.args[0]).to.deep.equal([ `foo${EOL}` ]);
+      assert.equal(errorStream.write.callCount, 0);
+      assert.equal(outputStream.write.callCount, 1);
+      assert.deepEqual(outputStream.write.args, [
+        [ `foo${EOL}` ]
+      ]);
     });
   });
 
@@ -76,7 +80,7 @@ describe('[convert-svg-core] CLI', () => {
 
   describe('#provider', () => {
     it('should return provider', () => {
-      expect(cli.provider).to.equal(provider);
+      assert.strictEqual(cli.provider, provider);
     });
   });
 });

--- a/packages/convert-svg-core/test/Converter.spec.js
+++ b/packages/convert-svg-core/test/Converter.spec.js
@@ -22,16 +22,11 @@
 
 'use strict';
 
-const chai = require('chai');
-const chaiAsPromised = require('chai-as-promised');
+const assert = require('assert');
 const sinon = require('sinon');
 
 const Converter = require('../src/Converter');
 const Provider = require('../src/Provider');
-
-chai.use(chaiAsPromised);
-
-const { expect } = chai;
 
 describe('[convert-svg-core] Converter', () => {
   let converter;
@@ -53,8 +48,13 @@ describe('[convert-svg-core] Converter', () => {
       it('should thrown an error', async() => {
         await converter.destroy();
 
-        await expect(converter.convert('<svg></svg>')).to.eventually.be.rejectedWith(Error,
-          'Converter has been destroyed. A new Converter must be created');
+        try {
+          await converter.convert('<svg></svg>');
+          // Should have thrown
+          assert.fail();
+        } catch (e) {
+          assert.equal(e.message, 'Converter has been destroyed. A new Converter must be created');
+        }
       });
     });
   });
@@ -66,35 +66,40 @@ describe('[convert-svg-core] Converter', () => {
       it('should thrown an error', async() => {
         await converter.destroy();
 
-        await expect(converter.convertFile('foo.svg')).to.eventually.be.rejectedWith(Error,
-          'Converter has been destroyed. A new Converter must be created');
+        try {
+          await converter.convertFile('foo.svg');
+          // Should have thrown
+          assert.fail();
+        } catch (e) {
+          assert.equal(e.message, 'Converter has been destroyed. A new Converter must be created');
+        }
       });
     });
   });
 
   describe('#destroy', () => {
     it('should destroy the converter', async() => {
-      expect(converter.destroyed).to.equal(false);
+      assert.equal(converter.destroyed, false);
 
       await converter.destroy();
 
-      expect(converter.destroyed).to.equal(true);
+      assert.equal(converter.destroyed, true);
     });
   });
 
   describe('#destroyed', () => {
     it('should indicate whether converter has been destroyed', async() => {
-      expect(converter.destroyed).to.equal(false);
+      assert.equal(converter.destroyed, false);
 
       await converter.destroy();
 
-      expect(converter.destroyed).to.equal(true);
+      assert.equal(converter.destroyed, true);
     });
   });
 
   describe('#provider', () => {
     it('should return provider', () => {
-      expect(converter.provider).to.equal(provider);
+      assert.strictEqual(converter.provider, provider);
     });
   });
 });

--- a/packages/convert-svg-core/test/Provider.spec.js
+++ b/packages/convert-svg-core/test/Provider.spec.js
@@ -22,7 +22,7 @@
 
 'use strict';
 
-const { expect } = require('chai');
+const assert = require('assert');
 
 const Provider = require('../src/Provider');
 
@@ -53,8 +53,12 @@ describe('[convert-svg-core] Provider', () => {
       it('should throw an error by default', () => {
         const provider = new Provider();
 
-        expect(() => provider[methodName]()).to.throw(Error,
-          `Provider#${methodName} abstract method is not implemented`);
+        assert.throws(() => {
+          provider[methodName]();
+        }, (error) => {
+          return error instanceof Error &&
+              error.message === `Provider#${methodName} abstract method is not implemented`;
+        });
       });
     });
   });
@@ -63,7 +67,7 @@ describe('[convert-svg-core] Provider', () => {
     it('should return Provider#getType transformed into lower case by default', () => {
       const provider = new TestProviderImpl();
 
-      expect(provider.getExtension()).to.equal('type');
+      assert.equal(provider.getExtension(), 'type');
     });
   });
 
@@ -71,7 +75,7 @@ describe('[convert-svg-core] Provider', () => {
     it('should return Provider#getType transformed into upper case by default', () => {
       const provider = new TestProviderImpl();
 
-      expect(provider.getFormat()).to.equal('TYPE');
+      assert.equal(provider.getFormat(), 'TYPE');
     });
   });
 });

--- a/packages/convert-svg-core/test/index.spec.js
+++ b/packages/convert-svg-core/test/index.spec.js
@@ -22,7 +22,7 @@
 
 'use strict';
 
-const { expect } = require('chai');
+const assert = require('assert');
 
 const API = require('../src/API');
 const CLI = require('../src/CLI');
@@ -33,25 +33,25 @@ const Provider = require('../src/Provider');
 describe('[convert-svg-core] index', () => {
   describe('.API', () => {
     it('should be a reference to API constructor', () => {
-      expect(index.API).to.equal(API, 'Must be API constructor');
+      assert.strictEqual(index.API, API, 'Must be API constructor');
     });
   });
 
   describe('.CLI', () => {
     it('should be a reference to CLI constructor', () => {
-      expect(index.CLI).to.equal(CLI, 'Must be CLI constructor');
+      assert.strictEqual(index.CLI, CLI, 'Must be CLI constructor');
     });
   });
 
   describe('.Converter', () => {
     it('should be a reference to Converter constructor', () => {
-      expect(index.Converter).to.equal(Converter, 'Must be Converter constructor');
+      assert.strictEqual(index.Converter, Converter, 'Must be Converter constructor');
     });
   });
 
   describe('.Provider', () => {
     it('should be a reference to Provider constructor', () => {
-      expect(index.Provider).to.equal(Provider, 'Must be Provider constructor');
+      assert.strictEqual(index.Provider, Provider, 'Must be Provider constructor');
     });
   });
 });

--- a/packages/convert-svg-test-helper/package.json
+++ b/packages/convert-svg-test-helper/package.json
@@ -27,8 +27,6 @@
     "url": "https://github.com/NotNinja/convert-svg.git"
   },
   "dependencies": {
-    "chai": "^4.1.2",
-    "chai-as-promised": "^7.1.1",
     "file-url": "^2.0.2",
     "lodash.clonedeep": "^4.5.0",
     "mocha": "^5.0.0",

--- a/packages/convert-svg-test-helper/src/Helper.js
+++ b/packages/convert-svg-test-helper/src/Helper.js
@@ -22,8 +22,7 @@
 
 'use strict';
 
-const chai = require('chai');
-const chaiAsPromised = require('chai-as-promised');
+const assert = require('assert');
 const cloneDeep = require('lodash.clonedeep');
 const fileUrl = require('file-url');
 const fs = require('fs');
@@ -34,9 +33,6 @@ const util = require('util');
 
 const coreTests = require('./tests.json');
 
-chai.use(chaiAsPromised);
-
-const { expect } = chai;
 const makeDirectory = util.promisify(fs.mkdir);
 const readFile = util.promisify(fs.readFile);
 const removeFile = util.promisify(rimraf);
@@ -167,8 +163,8 @@ class Helper {
       });
 
       afterEach(() => {
-        expect(api.createConverter.callCount).to.equal(1);
-        expect(converter.destroy.callCount).to.equal(1);
+        assert.equal(api.createConverter.callCount, 1);
+        assert.equal(converter.destroy.callCount, 1);
       });
 
       afterEach(() => {
@@ -214,13 +210,19 @@ class Helper {
           const method = testAPI ? api.convertFile.bind(api) : converter.convertFile.bind(converter);
 
           if (test.error) {
-            await expect(method(inputFilePath, options)).to.eventually.be.rejectedWith(Error, test.error);
+            try {
+              await method(inputFilePath, options);
+              // Should have thrown
+              assert.fail();
+            } catch (e) {
+              assert.equal(e.message, test.error);
+            }
           } else {
             const actualFilePath = await method(inputFilePath, options);
             const actual = await readFile(outputFilePath);
 
-            expect(actualFilePath).to.equal(outputFilePath);
-            expect(actual).to.deep.equal(expected);
+            assert.equal(actualFilePath, outputFilePath);
+            assert.deepEqual(actual, expected);
           }
         });
       });
@@ -252,8 +254,8 @@ class Helper {
       });
 
       afterEach(() => {
-        expect(api.createConverter.callCount).to.equal(1);
-        expect(converter.destroy.callCount).to.equal(1);
+        assert.equal(api.createConverter.callCount, 1);
+        assert.equal(converter.destroy.callCount, 1);
       });
 
       afterEach(() => {
@@ -299,11 +301,17 @@ class Helper {
           const method = testAPI ? api.convert.bind(api) : converter.convert.bind(converter);
 
           if (test.error) {
-            await expect(method(input, options)).to.eventually.be.rejectedWith(Error, test.error);
+            try {
+              await method(input, options);
+              // Should have thrown
+              assert.fail();
+            } catch (e) {
+              assert.equal(e.message, test.error);
+            }
           } else {
             const actual = await method(input, options);
 
-            expect(actual).to.deep.equal(expected);
+            assert.deepEqual(actual, expected);
           }
         });
       });
@@ -333,7 +341,7 @@ class Helper {
         const method = testAPI ? api.convert.bind(api) : converter.convert.bind(converter);
         const actual = await method(input);
 
-        expect(actual).to.deep.equal(expected);
+        assert.deepEqual(actual, expected);
       });
     });
   }

--- a/packages/convert-svg-to-jpeg/package.json
+++ b/packages/convert-svg-to-jpeg/package.json
@@ -29,7 +29,6 @@
     "convert-svg-core": "^0.3.3"
   },
   "devDependencies": {
-    "chai": "^4.1.2",
     "convert-svg-test-helper": "^0.3.3",
     "mocha": "^5.0.0"
   },

--- a/packages/convert-svg-to-jpeg/test/.eslintrc.json
+++ b/packages/convert-svg-to-jpeg/test/.eslintrc.json
@@ -4,6 +4,7 @@
     "mocha": true
   },
   "rules": {
+    "no-undefined": "off",
     "no-unused-expressions": "off"
   }
 }

--- a/packages/convert-svg-to-jpeg/test/JPEGProvider.spec.js
+++ b/packages/convert-svg-to-jpeg/test/JPEGProvider.spec.js
@@ -22,7 +22,7 @@
 
 'use strict';
 
-const { expect } = require('chai');
+const assert = require('assert');
 const { Provider } = require('convert-svg-core');
 
 const pkg = require('../package.json');
@@ -36,26 +36,26 @@ describe('[convert-svg-to-jpeg] JPEGProvider', () => {
   });
 
   it('should extend Provider', () => {
-    expect(provider).to.be.an.instanceOf(Provider);
+    assert.ok(provider instanceof Provider);
   });
 
   describe('#getBackgroundColor', () => {
     context('when background option was not specified', () => {
       it('should return white color', () => {
-        expect(provider.getBackgroundColor({})).to.equal('#FFF');
+        assert.equal(provider.getBackgroundColor({}), '#FFF');
       });
     });
 
     context('when background option was specified', () => {
       it('should return background', () => {
-        expect(provider.getBackgroundColor({ background: '#000' })).to.equal('#000');
+        assert.equal(provider.getBackgroundColor({ background: '#000' }), '#000');
       });
     });
   });
 
   describe('#getCLIOptions', () => {
     it('should return CLI options', () => {
-      expect(provider.getCLIOptions()).to.deep.equal([
+      assert.deepEqual(provider.getCLIOptions(), [
         {
           flags: '--quality <value>',
           description: 'specify quality for JPEG [100]',
@@ -67,31 +67,31 @@ describe('[convert-svg-to-jpeg] JPEGProvider', () => {
 
   describe('#getExtension', () => {
     it('should return output file extension', () => {
-      expect(provider.getExtension()).to.equal('jpeg');
+      assert.equal(provider.getExtension(), 'jpeg');
     });
   });
 
   describe('#getFormat', () => {
     it('should return output format', () => {
-      expect(provider.getFormat()).to.equal('JPEG');
+      assert.equal(provider.getFormat(), 'JPEG');
     });
   });
 
   describe('#getScreenshotOptions', () => {
     it('should return puppeteer screenshot options with quality option', () => {
-      expect(provider.getScreenshotOptions({ quality: 50 })).to.deep.equal({ quality: 50 });
+      assert.deepEqual(provider.getScreenshotOptions({ quality: 50 }), { quality: 50 });
     });
   });
 
   describe('#getType', () => {
     it('should return output type supported as supported by puppeteer screenshots', () => {
-      expect(provider.getType()).to.equal('jpeg');
+      assert.equal(provider.getType(), 'jpeg');
     });
   });
 
   describe('#getVersion', () => {
     it('should return version in package.json', () => {
-      expect(provider.getVersion()).to.equal(pkg.version);
+      assert.equal(provider.getVersion(), pkg.version);
     });
   });
 
@@ -102,7 +102,7 @@ describe('[convert-svg-to-jpeg] JPEGProvider', () => {
 
         provider.parseAPIOptions(options);
 
-        expect(options).to.deep.equal({ quality: 100 });
+        assert.deepEqual(options, { quality: 100 });
       });
     });
 
@@ -112,28 +112,37 @@ describe('[convert-svg-to-jpeg] JPEGProvider', () => {
 
         provider.parseAPIOptions(options);
 
-        expect(options).to.deep.equal({ quality: 0 });
+        assert.deepEqual(options, { quality: 0 });
 
         options.quality = 50;
 
         provider.parseAPIOptions(options);
 
-        expect(options).to.deep.equal({ quality: 50 });
+        assert.deepEqual(options, { quality: 50 });
 
         options.quality = 100;
 
         provider.parseAPIOptions(options);
 
-        expect(options).to.deep.equal({ quality: 100 });
+        assert.deepEqual(options, { quality: 100 });
       });
     });
 
     context('when quality option is out of range', () => {
       it('should throw an error', () => {
-        expect(() => provider.parseAPIOptions({ quality: -1 })).to.throw(Error,
-          'Value for quality option out of range. Use value between 0-100 (inclusive)');
-        expect(() => provider.parseAPIOptions({ quality: 101 })).to.throw(Error,
-          'Value for quality option out of range. Use value between 0-100 (inclusive)');
+        assert.throws(() => {
+          provider.parseAPIOptions({ quality: -1 });
+        }, (error) => {
+          return error instanceof Error &&
+              error.message === 'Value for quality option out of range. Use value between 0-100 (inclusive)';
+        });
+
+        assert.throws(() => {
+          provider.parseAPIOptions({ quality: 101 });
+        }, (error) => {
+          return error instanceof Error &&
+              error.message === 'Value for quality option out of range. Use value between 0-100 (inclusive)';
+        });
       });
     });
   });
@@ -144,11 +153,11 @@ describe('[convert-svg-to-jpeg] JPEGProvider', () => {
 
       provider.parseCLIOptions(options, {});
 
-      expect(options.quality).to.be.undefined;
+      assert.strictEqual(options.quality, undefined);
 
       provider.parseCLIOptions(options, { quality: 50 });
 
-      expect(options.quality).to.equal(50);
+      assert.equal(options.quality, 50);
     });
   });
 });

--- a/packages/convert-svg-to-png/package.json
+++ b/packages/convert-svg-to-png/package.json
@@ -28,7 +28,6 @@
     "convert-svg-core": "^0.3.3"
   },
   "devDependencies": {
-    "chai": "^4.1.2",
     "convert-svg-test-helper": "^0.3.3",
     "mocha": "^5.0.0"
   },

--- a/packages/convert-svg-to-png/test/PNGProvider.spec.js
+++ b/packages/convert-svg-to-png/test/PNGProvider.spec.js
@@ -22,7 +22,7 @@
 
 'use strict';
 
-const { expect } = require('chai');
+const assert = require('assert');
 const { Provider } = require('convert-svg-core');
 
 const pkg = require('../package.json');
@@ -36,64 +36,64 @@ describe('[convert-svg-to-png] PNGProvider', () => {
   });
 
   it('should extend Provider', () => {
-    expect(provider).to.be.an.instanceOf(Provider);
+    assert.ok(provider instanceof Provider);
   });
 
   describe('#getBackgroundColor', () => {
     context('when background option was not specified', () => {
       it('should return transparent color', () => {
-        expect(provider.getBackgroundColor({})).to.equal('transparent');
+        assert.equal(provider.getBackgroundColor({}), 'transparent');
       });
     });
 
     context('when background option was specified', () => {
       it('should return background', () => {
-        expect(provider.getBackgroundColor({ background: '#000' })).to.equal('#000');
+        assert.equal(provider.getBackgroundColor({ background: '#000' }), '#000');
       });
     });
   });
 
   describe('#getCLIOptions', () => {
     it('should return null', () => {
-      expect(provider.getCLIOptions()).to.be.null;
+      assert.strictEqual(provider.getCLIOptions(), null);
     });
   });
 
   describe('#getExtension', () => {
     it('should return output file extension', () => {
-      expect(provider.getExtension()).to.equal('png');
+      assert.equal(provider.getExtension(), 'png');
     });
   });
 
   describe('#getFormat', () => {
     it('should return output format', () => {
-      expect(provider.getFormat()).to.equal('PNG');
+      assert.equal(provider.getFormat(), 'PNG');
     });
   });
 
   describe('#getScreenshotOptions', () => {
     context('when background option was not specified', () => {
       it('should return puppeteer screenshot options with background omitted', () => {
-        expect(provider.getScreenshotOptions({})).to.deep.equal({ omitBackground: true });
+        assert.deepEqual(provider.getScreenshotOptions({}), { omitBackground: true });
       });
     });
 
     context('when background option was specified', () => {
       it('should return puppeteer screenshot options with background', () => {
-        expect(provider.getScreenshotOptions({ background: '#000' })).to.deep.equal({ omitBackground: false });
+        assert.deepEqual(provider.getScreenshotOptions({ background: '#000' }), { omitBackground: false });
       });
     });
   });
 
   describe('#getType', () => {
     it('should return output type supported as supported by puppeteer screenshots', () => {
-      expect(provider.getType()).to.equal('png');
+      assert.equal(provider.getType(), 'png');
     });
   });
 
   describe('#getVersion', () => {
     it('should return version in package.json', () => {
-      expect(provider.getVersion()).to.equal(pkg.version);
+      assert.equal(provider.getVersion(), pkg.version);
     });
   });
 
@@ -103,7 +103,7 @@ describe('[convert-svg-to-png] PNGProvider', () => {
 
       provider.parseAPIOptions(options);
 
-      expect(options).to.deep.equal({});
+      assert.deepEqual(options, {});
     });
   });
 
@@ -113,7 +113,7 @@ describe('[convert-svg-to-png] PNGProvider', () => {
 
       provider.parseCLIOptions(options);
 
-      expect(options).to.deep.equal({});
+      assert.deepEqual(options, {});
     });
   });
 });


### PR DESCRIPTION
It would appear that everything that we do with `chai` could easily be done with the built-in `assert` module, so I'd like to switch over to `assert`, dropping `chai` as a devDependency.