### PR TITLE
Catch resource errors

### DIFF
--- a/packages/convert-svg-core/src/Converter.js
+++ b/packages/convert-svg-core/src/Converter.js
@@ -278,16 +278,16 @@ html { background-color: ${provider.getBackgroundColor(options)}; }
 
     await writeFile(tempFile.path, html);
 
-    this[_page].on('requestfinished', msg => {
-      let resource = msg.url();
-      let statusCode = msg.response().status();
+    this[_page].on('requestfinished', (msg) => {
+      const resource = msg.url();
+      const statusCode = msg.response().status();
       if (statusCode >= 400) {
         throw new Error(`A request to ${resource} failed with ${statusCode}`);
       }
     });
 
-    this[_page].on('requestfailed', msg => {
-      let resource = msg.url();
+    this[_page].on('requestfailed', (msg) => {
+      const resource = msg.url();
       throw new Error(`Unable to load resource: ${resource}`);
     });
 

--- a/packages/convert-svg-core/src/Converter.js
+++ b/packages/convert-svg-core/src/Converter.js
@@ -278,6 +278,18 @@ html { background-color: ${provider.getBackgroundColor(options)}; }
 
     await writeFile(tempFile.path, html);
 
+    this[_page].on('requestfinished', msg => {
+      let resource = msg.url();
+      let statusCode = msg.response().status();
+      if (statusCode >= 400) {
+        throw new Error(`A request to ${resource} failed with ${statusCode}`);
+      }
+    });
+
+    this[_page].on('requestfailed', msg => {
+      throw new Error('Unable to load a resource.');
+    });
+
     await this[_page].goto(fileUrl(tempFile.path));
 
     return this[_page];

--- a/packages/convert-svg-core/src/Converter.js
+++ b/packages/convert-svg-core/src/Converter.js
@@ -287,7 +287,8 @@ html { background-color: ${provider.getBackgroundColor(options)}; }
     });
 
     this[_page].on('requestfailed', msg => {
-      throw new Error('Unable to load a resource.');
+      let resource = msg.url();
+      throw new Error(`Unable to load resource: ${resource}`);
     });
 
     await this[_page].goto(fileUrl(tempFile.path));

--- a/packages/convert-svg-to-png/bin/convert-svg-to-png
+++ b/packages/convert-svg-to-png/bin/convert-svg-to-png
@@ -28,9 +28,13 @@ const { CLI } = require('convert-svg-core');
 
 const PNGProvider = require('../src/PNGProvider');
 
+
 (async() => {
   const cli = new CLI(new PNGProvider());
-
+  process.on('unhandledRejection', e => {
+    cli.error(`convert-svg-to-png failed: ${e.stack}`);
+    process.exit(1);
+  })
   try {
     await cli.parse(process.argv);
   } catch (e) {

--- a/packages/convert-svg-to-png/bin/convert-svg-to-png
+++ b/packages/convert-svg-to-png/bin/convert-svg-to-png
@@ -31,7 +31,7 @@ const PNGProvider = require('../src/PNGProvider');
 
 (async() => {
   const cli = new CLI(new PNGProvider());
-  process.on('unhandledRejection', e => {
+  process.on('unhandledRejection', (e) => {
     cli.error(`convert-svg-to-png failed: ${e.stack}`);
     process.exit(1);
   })


### PR DESCRIPTION
As I mentioned in #42, here's "enough" code to cause rendering to stop on a resource load failure.  The first section at L281 catches server errors and not founds, while the second at 289 _should_ catch things such as the network connection dropping during load, timeouts, etc... (I should point out that I have not yet tested that specific section.)

I don't at all expect this to be merged as is, as it still has a number of things to be addressed.  Likely highest on the list is that throwing an error in those event handlers causes an unhandled promise rejection that I spent a pretty long time trying to catch without luck.  I'm not sure if it's causing something inside Puppeteer to reject or if it's just something I managed to miss in the Converter code, but as you can see in the `convert-svg-to-png` change, the only way I was able to get around it for the time being was to add a global `unhandledRejection` handler.  Additionally, when used as a library, I had to add a similar handler to my application to prevent the promise rejection issue as well.

Secondly, I need to write some tests for this, though I was hoping to get the unhandled rejection issue fixed first.  If you have any suggestions on that, I'd be happy to dive in a bit more.  I'll also rebase/squash this and amend the commit message to match your style once we've settled on some code you're ready to merge.

EDIT: I also just realized I was a dummy and opened this against `master` - Please feel free to ignore this one.  I will open a new PR against `develop`.